### PR TITLE
Update shapes.js

### DIFF
--- a/js/parsers/shapes.js
+++ b/js/parsers/shapes.js
@@ -36,6 +36,10 @@ export const colourDB = {
     11: '#6B4E25',
     12: '#DB66D1',
     13: '#AFADAF',
+    14: '#000000',
+    15: '#ff3f3f',
+    16: '#ff7f7f',
+    17: '#ff7f7f'
   },
 };
 
@@ -95,10 +99,13 @@ export function Arrow(featurestart, featureend, direction, fill, stroke, strokeW
       const colourValue = +value.replace(/(^'|'$)/g, '');
 
       if (!isNaN(colourValue)) {
-        if (colourValue < 14 && colourValue > -1) {
+        if (colourValue < 18 && colourValue > -1) {
           this.fill = colourDB.artemis[colourValue];
           // console.log(this.ID, this.product, this.fill, colour_value);
         }
+      }
+      else {
+        this.fill = colourValue;
       }
     }
   }


### PR DESCRIPTION
Added extra Artemis colours to include all 18, and support for hex and/or named colours. If an invalid colour string is input it will simply fail to change the colour of the block