### PR TITLE
Add nwk to list of tree suffices

### DIFF
--- a/js/actions/fileInput.js
+++ b/js/actions/fileInput.js
@@ -64,6 +64,7 @@ const analyseIncomingData = (fileName, fileContents) => {
   case 'nex': // fallthrough
   case 'newick': // fallthrough
   case 'new': // fallthrough
+  case 'nwk': // fallthrough
   case 'tree': // fallthrough
   case 'tre':
     if (fileContents.startsWith('#NEXUS')) {


### PR DESCRIPTION
nwk is a common tree suffix for newick files, but Phandango fails to read them. I've added one line to fix this.